### PR TITLE
🎨 Palette: Add visibility toggles to all API key fields

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-12 - Added API Key Visibility Toggles
+**Learning:** Adding the "Show key" eye-icon to password fields is a major UX win, allowing users to verify pasted keys without leaving them permanently exposed. The existing `.secret-input-group` and `.secret-visibility-toggle` CSS classes and JavaScript logic in `setupSecretVisibilityToggles()` made this easy to apply consistently to newly discovered or overlooked password fields (`dashscope-api-key`, `deepl-api-key`, `doubao-api-key`, `soniox-api-key`).
+**Action:** When adding or encountering new `type="password"` fields that users need to copy-paste into, always wrap them in the `secret-input-group` layout with the visibility toggle button to maintain consistent and pleasant UX.

--- a/ui/templates/index.html
+++ b/ui/templates/index.html
@@ -414,8 +414,19 @@
                                     hidden></span>
                             </label>
                             <div style="display: flex; align-items: center; gap: 16px;">
-                                <input type="password" id="dashscope-api-key" class="form-control" placeholder="sk-..."
-                                    style="flex: 1;">
+                                <div class="secret-input-group" style="flex: 1;">
+                                    <input type="password" id="dashscope-api-key" class="form-control" placeholder="sk-...">
+                                    <button
+                                        type="button"
+                                        class="secret-visibility-toggle"
+                                        data-target-input="dashscope-api-key"
+                                        aria-label="Show key"
+                                        aria-pressed="false"
+                                        title="Show key"
+                                    >
+                                        <span class="secret-visibility-icon" aria-hidden="true">&#128065;</span>
+                                    </button>
+                                </div>
                                 <div style="display:flex; align-items:center; gap:8px; white-space:nowrap;">
                                     <span data-i18n="label.international">国际版</span>
                                     <label class="switch" style="margin:0;">
@@ -438,7 +449,19 @@
 
                         <div class="api-key-group">
                             <label for="deepl-api-key" data-i18n="label.deeplKey">DeepL API Key (可选，用于翻译)</label>
-                            <input type="password" id="deepl-api-key" class="form-control" placeholder="...">
+                            <div class="secret-input-group">
+                                <input type="password" id="deepl-api-key" class="form-control" placeholder="...">
+                                <button
+                                    type="button"
+                                    class="secret-visibility-toggle"
+                                    data-target-input="deepl-api-key"
+                                    aria-label="Show key"
+                                    aria-pressed="false"
+                                    title="Show key"
+                                >
+                                    <span class="secret-visibility-icon" aria-hidden="true">&#128065;</span>
+                                </button>
+                            </div>
                             <small class="form-text">
                                 <a href="https://www.deepl.com/en/pro-api" target="_blank"
                                     data-i18n="link.getApiKey">获取API Key →</a>
@@ -447,7 +470,19 @@
 
                         <div class="api-key-group">
                             <label for="doubao-api-key" data-i18n="label.doubaoKey">豆包录音文件 API Key（可选）</label>
-                            <input type="password" id="doubao-api-key" class="form-control" placeholder="API Key">
+                            <div class="secret-input-group">
+                                <input type="password" id="doubao-api-key" class="form-control" placeholder="API Key">
+                                <button
+                                    type="button"
+                                    class="secret-visibility-toggle"
+                                    data-target-input="doubao-api-key"
+                                    aria-label="Show key"
+                                    aria-pressed="false"
+                                    title="Show key"
+                                >
+                                    <span class="secret-visibility-icon" aria-hidden="true">&#128065;</span>
+                                </button>
+                            </div>
                             <small class="form-text">
                                 <span data-i18n="hint.doubaoKey">用于豆包录音文件识别后端。</span>
                             </small>
@@ -461,7 +496,19 @@
 
                         <div class="api-key-group">
                             <label for="soniox-api-key" data-i18n="label.sonioxKey">Soniox API Key（可选）</label>
-                            <input type="password" id="soniox-api-key" class="form-control" placeholder="...">
+                            <div class="secret-input-group">
+                                <input type="password" id="soniox-api-key" class="form-control" placeholder="...">
+                                <button
+                                    type="button"
+                                    class="secret-visibility-toggle"
+                                    data-target-input="soniox-api-key"
+                                    aria-label="Show key"
+                                    aria-pressed="false"
+                                    title="Show key"
+                                >
+                                    <span class="secret-visibility-icon" aria-hidden="true">&#128065;</span>
+                                </button>
+                            </div>
                             <small class="form-text">
                                 <span data-i18n="hint.sonioxKey">支持60+语言的语音识别。</span>
                                 <a href="https://console.soniox.com/" target="_blank" data-i18n="link.getApiKey">获取API


### PR DESCRIPTION
💡 **What:** Added the `secret-input-group` class and `secret-visibility-toggle` button to the `dashscope-api-key`, `deepl-api-key`, `doubao-api-key`, and `soniox-api-key` input fields in the UI.

🎯 **Why:** To improve UX and consistency. Previously, only the LLM API key had a visibility toggle. Users often need to verify that they have pasted long API keys correctly. Being able to toggle the visibility provides immediate feedback without permanently exposing sensitive tokens on the screen.

📸 **Before/After:** The API Key configuration section now features the eye icon (visibility toggle) adjacent to all password-type API key inputs, functioning identically to the LLM settings.

♿ **Accessibility:** Re-used existing `aria-label`, `aria-pressed`, and `title` attributes on the added toggle buttons to ensure screen readers appropriately announce their state and purpose.

---
*PR created automatically by Jules for task [8171234214572004321](https://jules.google.com/task/8171234214572004321) started by @febilly*